### PR TITLE
Added CSV export support.

### DIFF
--- a/pdbdump/pdbdump/pdbdump.cpp
+++ b/pdbdump/pdbdump/pdbdump.cpp
@@ -71,6 +71,11 @@ int wmain(int argc, wchar_t* argv[])
         wprintf(L"BEGIN TRANSACTION;\n");
         wprintf(L"\n");
         break;
+    case Format::CSV:
+        wprintf(L"\"pdb\"");
+        SYMBOL_PROPERTY(SYMBOL, __, CSV_CREATE_COLUMN);
+        wprintf(L"\n");
+        break;
     }
 
     ULONG pdbId = 0;
@@ -114,6 +119,8 @@ int wmain(int argc, wchar_t* argv[])
             case Format::SQLITE3:
                 wprintf(L"INSERT INTO pdb (id, name) VALUES (%lu, \"%s\");\n", pdbId, argv[i]);
                 break;
+            case Format::CSV:
+                break;
             }
 
             ULONG topics = 0;
@@ -131,6 +138,8 @@ int wmain(int argc, wchar_t* argv[])
                 case Format::XML:
                     break;
                 case Format::SQLITE3:
+                    break;
+                case Format::CSV:
                     break;
                 }
                 CComPtr<IDiaEnumSymbols> enumSymbols;
@@ -154,6 +163,9 @@ int wmain(int argc, wchar_t* argv[])
                             SYMBOL_PROPERTY(SYMBOL, __, SERIALIZE_PROPERTY_NAME);
                             wprintf(L") VALUES (%lu", pdbId);
                             break;
+                        case Format::CSV:
+                            wprintf(L"%d", i);
+                            break;
                         }
                         SYMBOL_PROPERTY(SYMBOL, __, SERIALIZE_PROPERTY);
                         switch (format) {
@@ -165,6 +177,9 @@ int wmain(int argc, wchar_t* argv[])
                             break;
                         case Format::SQLITE3:
                             wprintf(L");\n");
+                            break;
+                        case Format::CSV:
+                            wprintf(L"\n");
                             break;
                         }
                         symbol = 0;
@@ -191,6 +206,9 @@ int wmain(int argc, wchar_t* argv[])
                 wprintf(L"  </pdb>\n");
                 break;
             case Format::SQLITE3:
+                wprintf(L"\n");
+                break;
+            case Format::CSV:
                 wprintf(L"\n");
                 break;
             }

--- a/pdbdump/pdbdump/pdbdump.h
+++ b/pdbdump/pdbdump/pdbdump.h
@@ -235,6 +235,11 @@
         wprintf(L"  " L## #x L" " SQLITE3_TYPE_##type L" NOT NULL,\n"); \
     }
 
+#define CSV_CREATE_COLUMN(topic, __, x, default, type, ...)         \
+    if (DUMP_PROPERTY(topic, __, x) == true) {                      \
+        wprintf(L",\"" L## #x L"\"");                               \
+    }
+
 #define DEFINE_PROPERTY_BOOL static BOOL value = 0;
 #define DEFINE_PROPERTY_DWORD static DWORD value = 0;
 #define DEFINE_PROPERTY_LONG static LONG value = 0;
@@ -254,6 +259,9 @@
     case Format::SQLITE3:                                 \
         wprintf(L", %d", value);                          \
         break;                                            \
+    case Format::CSV:                                     \
+        wprintf(L",%d", value);                           \
+        break;                                            \
     }
 
 #define SERIALIZE_PROPERTY_DWORD(x)                        \
@@ -266,6 +274,9 @@
         break;                                             \
     case Format::SQLITE3:                                  \
         wprintf(L", %lu", value);                          \
+        break;                                             \
+    case Format::CSV:                                      \
+        wprintf(L",%lu", value);                           \
         break;                                             \
     }
 
@@ -280,6 +291,9 @@
     case Format::SQLITE3:                                  \
         wprintf(L", %ld", value);                          \
         break;                                             \
+    case Format::CSV:                                      \
+        wprintf(L",%ld", value);                           \
+        break;                                             \
     }
 
 #define SERIALIZE_PROPERTY_ULONGLONG(x)                     \
@@ -293,6 +307,9 @@
     case Format::SQLITE3:                                   \
         wprintf(L", %llu", value);                          \
         break;                                              \
+    case Format::CSV:                                       \
+        wprintf(L",%llu", value);                           \
+        break;                                              \
     }
 
 #define SERIALIZE_PROPERTY_GUID(x)         \
@@ -304,6 +321,9 @@
         break;                             \
     case Format::SQLITE3:                  \
         wprintf(L", \"\"");                \
+        break;                             \
+    case Format::CSV:                      \
+        wprintf(L",0");                    \
         break;                             \
     }
 
@@ -317,6 +337,9 @@
     case Format::SQLITE3:                  \
         wprintf(L", \"\"");                \
         break;                             \
+    case Format::CSV:                      \
+        wprintf(L",0");                    \
+        break;                             \
     }
 
 #define SERIALIZE_PROPERTY_BSTR(x)                                     \
@@ -329,6 +352,9 @@
         break;                                                         \
     case Format::SQLITE3:                                              \
         wprintf(L", \"%ls\"", value);                                  \
+        break;                                                         \
+    case Format::CSV:                                                  \
+        wprintf(L",\"%ls\"", value);                 \
         break;                                                         \
     }
 
@@ -352,6 +378,7 @@
     A(_, __, L"--list", showList = true;)       \
     A(_, __, L"--json", format = Format::JSON;) \
     A(_, __, L"--xml", format = Format::XML;)   \
+    A(_, __, L"--csv", format = Format::CSV;)   \
     A(_, __, L"--sqlite3", format = Format::SQLITE3;)
 
 #define OPTION_HANDLER(_, __, x, handler, ...) \
@@ -366,5 +393,6 @@
 enum class Format {
     JSON,
     XML,
-    SQLITE3
+    SQLITE3,
+    CSV
 };


### PR DESCRIPTION
This PR adds CSV export support. This can be used with the `.import` command in sqlite for significantly faster data imports over the `INSERT` approach.

Importing into sqlite can be done as follows:

```
.open "C:\\path\\to\\pdb.sqlite"
.mode csv
.import "C:\\path\\to\\pdb.csv" tablename
```

On the Windows kernel binary (ntkrnlmp) this approach takes approximately 30 seconds and 31MB of CSV, versus 233MB of SQL commands and 8+ hours (I cancelled before it completed).